### PR TITLE
Implement flavor extra spec access interface

### DIFF
--- a/src/Compute/v2/Api.php
+++ b/src/Compute/v2/Api.php
@@ -889,4 +889,42 @@ class Api extends AbstractApi
             ],
         ];
     }
+
+    public function getExtraSpecs(): array
+    {
+        return [
+            'method'  => 'GET',
+            'path'    => 'flavors/{flavorId}/os-extra_specs',
+            'params'  => [
+                'flavorId' => $this->params->urlId('flavor')
+            ],
+        ];
+    }
+
+    public function postExtraSpecs(): array
+    {
+        return [
+            'method'  => 'POST',
+            'path'    => 'flavors/{flavorId}/os-extra_specs',
+            'jsonKey' => 'extra_specs',
+            'params'  => [
+                'flavorId' => $this->params->urlId('flavor'),
+                'diskIoLimit' => $this->notRequired($this->params->extraSpecsSetDiskIoLimit()),
+                'diskReadBytesSec' => $this->notRequired($this->params->extraSpecsSetDiskReadBytesSec()),
+                'diskWriteBytesSec' => $this->notRequired($this->params->extraSpecsSetDiskWriteBytesSec()),
+            ],
+        ];
+    }
+
+    public function deleteExtraSpec(): array
+    {
+        return [
+            'method'  => 'DELETE',
+            'path'    => 'flavors/{flavorId}/os-extra_specs/{extraSpecKey}',
+            'params'  => [
+                'flavorId' => $this->params->urlId('flavor'),
+                'extraSpecKey' => $this->params->extraSpecKey(),
+            ],
+        ];
+    }
 }

--- a/src/Compute/v2/Models/ExtraSpecs.php
+++ b/src/Compute/v2/Models/ExtraSpecs.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenStack\Compute\v2\Models;
+
+use OpenStack\Common\Resource\Creatable;
+use OpenStack\Common\Resource\OperatorResource;
+use OpenStack\Common\Resource\Retrievable;
+
+/**
+ * Represents a Compute v2 ExtraSpecs.
+ *
+ * @property \OpenStack\Compute\v2\Api $api
+ */
+class ExtraSpecs extends OperatorResource implements Retrievable, Creatable
+{
+    protected $resourceKey  = 'extra_specs';
+
+    /** @var int */
+    public $diskIoLimit;
+
+    /** @var int */
+    public $diskWriteBytesSec;
+
+    /** @var int */
+    public $diskReadBytesSec;
+
+    /** @var string */
+    public $flavorId;
+
+    protected $aliases = [
+        'disk_io_limit'  => 'diskIoLimit',
+        'disk_write_bytes_sec'  => 'diskWriteBytesSec',
+        'disk_read_bytes_sec'  => 'diskReadBytesSec',
+    ];
+
+    public function retrieve()
+    {
+        $response = $this->executeWithState($this->api->getExtraSpecs());
+        return $this->populateFromResponse($response);
+    }
+
+    public function create(array $userOptions): Creatable
+    {
+        $this->populateFromArray($userOptions);
+        $response = $this->executeWithState($this->api->postExtraSpecs());
+        return $this->populateFromResponse($response);
+    }
+
+    public function deleteExtraSpec(string $extraSpec)
+    {
+        $extraSpecKey = array_search($extraSpec, $this->aliases, true);
+        $this->execute(
+            $this->api->deleteExtraSpec(),
+            [
+                'flavorId' => $this->flavorId,
+                'extraSpecKey' => $extraSpecKey ?: $extraSpec,
+            ]
+        );
+    }
+}

--- a/src/Compute/v2/Models/Flavor.php
+++ b/src/Compute/v2/Models/Flavor.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace OpenStack\Compute\v2\Models;
 
+use OpenStack\Common\Api\OperatorTrait;
 use OpenStack\Common\Resource\Creatable;
 use OpenStack\Common\Resource\Deletable;
 use OpenStack\Common\Resource\Listable;
 use OpenStack\Common\Resource\OperatorResource;
+use OpenStack\Common\Resource\ResourceInterface;
 use OpenStack\Common\Resource\Retrievable;
 
 /**
@@ -17,6 +19,8 @@ use OpenStack\Common\Resource\Retrievable;
  */
 class Flavor extends OperatorResource implements Listable, Retrievable, Creatable, Deletable
 {
+    use OperatorTrait;
+
     /** @var int */
     public $disk;
 
@@ -66,5 +70,10 @@ class Flavor extends OperatorResource implements Listable, Retrievable, Creatabl
     public function delete()
     {
         $this->execute($this->api->deleteFlavor(), ['id' => (string) $this->id]);
+    }
+
+    public function getExtraSpecs(): ResourceInterface
+    {
+        return $this->model(ExtraSpecs::class, ['flavorId' => $this->id]);
     }
 }

--- a/src/Compute/v2/Params.php
+++ b/src/Compute/v2/Params.php
@@ -657,4 +657,38 @@ EOL
     {
         return $this->quotaSetLimit('server_group_members', 'The number of allowed members for each server group.');
     }
+
+    protected function extraSpecsSetInt($sentAs, $description): array
+    {
+        return [
+            'type'        => self::INT_TYPE,
+            'location'    => self::JSON,
+            'sentAs'      => $sentAs,
+            'description' => $description,
+        ];
+    }
+
+    public function extraSpecsSetDiskIoLimit(): array
+    {
+        return $this->extraSpecsSetInt('disk_io_limit', 'Specifies the upper limit for disk utilization in I/O per second. The utilization of a virtual machine will not exceed this limit, even if there are available resources. The default value is -1 which indicates unlimited usage.');
+    }
+
+    public function extraSpecsSetDiskWriteBytesSec(): array
+    {
+        return $this->extraSpecsSetInt('disk_write_bytes_sec', 'Specifies the maximum disk write speed in bytes per second for a VM user.');
+    }
+
+    public function extraSpecsSetDiskReadBytesSec(): array
+    {
+        return $this->extraSpecsSetInt('disk_read_bytes_sec', 'Specifies the maximum disk read speed in bytes per second for a VM user.');
+    }
+
+    public function extraSpecKey(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::URL,
+            'description' => 'Extra spec key.',
+        ];
+    }
 }


### PR DESCRIPTION
Implements interface to get, set and delete flavor [extra specs](https://docs.openstack.org/nova/latest/user/flavors.html#extra-specs).

Allowed extra specs:
- **disk_io_limit**
- **disk_write_bytes_sec**
- **disk_read_bytes_sec**